### PR TITLE
Declare port parameter

### DIFF
--- a/src/web_video_server.cpp
+++ b/src/web_video_server.cpp
@@ -54,7 +54,8 @@ WebVideoServer::WebVideoServer(rclcpp::Node::SharedPtr &nh, rclcpp::Node::Shared
         async_web_server_cpp::HttpReply::stock_reply(async_web_server_cpp::HttpReply::not_found))
 {
   rclcpp::Parameter parameter;
-  if (private_nh->get_parameter("port", parameter)) {
+  nh->declare_parameter("port", rclcpp::PARAMETER_INTEGER);
+  if (nh->get_parameter("port", parameter)) {
     port_ = parameter.as_int();
   } else {
     port_ = 8080;


### PR DESCRIPTION
The port parameter needs to be declared so that it can be set in the launch file. 