### PR TITLE
When connecting to a subscriber to a publisher, we first inspect the …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ pkg_check_modules(avutil libavutil REQUIRED)
 pkg_check_modules(swscale libswscale REQUIRED)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 ###################################################

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -3,11 +3,9 @@
 
 #include "web_video_server/utils.h"
 #include <string>
-#include <optional>
 #include <image_transport/image_transport.hpp>
 #include <image_transport/transport_hints.hpp>
 #include <opencv2/opencv.hpp>
-#include "web_video_server/utils.h"
 #include "async_web_server_cpp/http_server.hpp"
 #include "async_web_server_cpp/http_request.hpp"
 
@@ -81,38 +79,6 @@ private:
   bool initialized_;
 
   void imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &msg);
-
-  /**
-   * @brief Detects QoS profile settings used by publishers on a specified topic.
-   * 
-   * This function queries the ROS2 middleware to discover publishers on the 
-   * given topic and extracts their QoS profile settings. It's useful for 
-   * creating subscribers that automatically match the publisher's QoS.
-   * 
-   * @param nh The ROS2 node.
-   * @param topic The full name of the topic to query.
-   *
-   * @return The detected QoS profile if a publisher is found, std::nullopt otherwise
-   */
-  static std::optional<rmw_qos_profile_t> detect_publisher_qos(rclcpp::Node::SharedPtr nh,
-                                                               const std::string &topic);
-
-  /**
-   * @brief Get QoS profile based on user selection or auto-detect.
-   * 
-   * If the profile name is "auto" (the default one), this function queries the ROS2
-   * middleware to discover publishers on the given topic and extracts their QoS
-   * profile settings. Otherwise it returns a profile based on the given name.
-   * 
-   * @param nh The ROS2 node.
-   * @param profile_name The QoS profile name e.g. "auto" or "default".
-   * @param topic The full name of the topic to query.
-   *
-   * @return The detected QoS profile if a publisher is found, std::nullopt otherwise
-   */
-  static std::optional<rmw_qos_profile_t> get_qos_profile(rclcpp::Node::SharedPtr nh, 
-                                                          const std::string &profile_name, 
-                                                          const std::string& topic);
 };
 
 class ImageStreamerType

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -1,7 +1,7 @@
 #ifndef IMAGE_STREAMER_H_
 #define IMAGE_STREAMER_H_
 
-#include <rclcpp/rclcpp.hpp>
+#include "web_video_server/utils.h"
 #include <image_transport/image_transport.hpp>
 #include <image_transport/transport_hints.hpp>
 #include <opencv2/opencv.hpp>
@@ -62,6 +62,7 @@ protected:
   virtual void restreamFrame(double max_age);
   virtual void initialize(const cv::Mat &);
 
+
   image_transport::Subscriber image_sub_;
   int output_width_;
   int output_height_;
@@ -78,6 +79,38 @@ private:
   bool initialized_;
 
   void imageCallback(const sensor_msgs::msg::Image::ConstSharedPtr &msg);
+
+  /**
+   * @brief Detects QoS profile settings used by publishers on a specified topic.
+   * 
+   * This function queries the ROS2 middleware to discover publishers on the 
+   * given topic and extracts their QoS profile settings. It's useful for 
+   * creating subscribers that automatically match the publisher's QoS.
+   * 
+   * @param nh The ROS2 node.
+   * @param topic The full name of the topic to query.
+   *
+   * @return The detected QoS profile if a publisher is found, std::nullopt otherwise
+   */
+  static std::optional<rmw_qos_profile_t> detect_publisher_qos(rclcpp::Node::SharedPtr nh,
+                                                               const std::string &topic);
+
+  /**
+   * @brief Get QoS profile based on user selection or auto-detect.
+   * 
+   * If the profile name is "auto" (the default one), this function queries the ROS2
+   * middleware to discover publishers on the given topic and extracts their QoS
+   * profile settings. Otherwise it returns a profile based on the given name.
+   * 
+   * @param nh The ROS2 node.
+   * @param profile_name The QoS profile name e.g. "auto" or "default".
+   * @param topic The full name of the topic to query.
+   *
+   * @return The detected QoS profile if a publisher is found, std::nullopt otherwise
+   */
+  static std::optional<rmw_qos_profile_t> get_qos_profile(rclcpp::Node::SharedPtr nh, 
+                                                          const std::string &profile_name, 
+                                                          const std::string& topic);
 };
 
 class ImageStreamerType

--- a/include/web_video_server/image_streamer.h
+++ b/include/web_video_server/image_streamer.h
@@ -2,6 +2,8 @@
 #define IMAGE_STREAMER_H_
 
 #include "web_video_server/utils.h"
+#include <string>
+#include <optional>
 #include <image_transport/image_transport.hpp>
 #include <image_transport/transport_hints.hpp>
 #include <opencv2/opencv.hpp>

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -36,15 +36,15 @@ std::optional<rmw_qos_profile_t> ImageTransportImageStreamer::detect_publisher_q
 {
   RCLCPP_INFO(nh->get_logger(), "Attempting to auto-detect QoS for topic: %s", topic.c_str());
 
-  auto topic_endpoint_info_array = nh->get_publishers_info_by_topic(topic);
+  const auto topic_endpoint_info_array = nh->get_publishers_info_by_topic(topic);
   if (topic_endpoint_info_array.empty()) {
     RCLCPP_WARN(nh->get_logger(), "No publishers found for topic: %s", topic.c_str());
     return std::nullopt;
   }
 
   // Use the first publisher's QoS as reference.
-  auto endpoint_info = topic_endpoint_info_array.front();
-  auto qos_profile = endpoint_info.qos_profile();
+  const auto endpoint_info = topic_endpoint_info_array.front();
+  const auto qos_profile = endpoint_info.qos_profile();
 
   // Log the detected QoS settings.
   const std::string reliability =

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -47,9 +47,9 @@ std::optional<rmw_qos_profile_t> ImageTransportImageStreamer::detect_publisher_q
   auto qos_profile = endpoint_info.qos_profile();
 
   // Log the detected QoS settings.
-  std::string reliability =
+  const std::string reliability =
       (qos_profile.reliability() == rclcpp::ReliabilityPolicy::Reliable) ? "RELIABLE" : "BEST_EFFORT";
-  std::string durability =
+  const std::string durability =
       (qos_profile.durability() == rclcpp::DurabilityPolicy::TransientLocal) ? "TRANSIENT_LOCAL" : "VOLATILE";
 
   RCLCPP_INFO(nh->get_logger(), "Detected QoS - Reliability: %s, Durability: %s, History depth: %zu",
@@ -125,7 +125,7 @@ void ImageTransportImageStreamer::start()
   }
 
   // Get QoS profile based on user selection or auto-detect.
-  std::optional<rmw_qos_profile_t> qos_profile = get_qos_profile(nh_, qos_profile_name_, topic_);
+  const auto qos_profile = get_qos_profile(nh_, qos_profile_name_, topic_);
 
   // Create subscriber
   using std::placeholders::_1;

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -58,23 +58,20 @@ std::optional<rmw_qos_profile_t> ImageTransportImageStreamer::detect_publisher_q
   // Convert rclcpp QoS to rmw QoS profile.
   rmw_qos_profile_t rmw_qos = rmw_qos_profile_default;
 
+  // Set defaults
+  rmw_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  rmw_qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+  rmw_qos.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+  rmw_qos.depth = qos_profile.depth();
+
   // Set reliability
   if (qos_profile.reliability() == rclcpp::ReliabilityPolicy::Reliable) {
     rmw_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  } else {
-    rmw_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
   }
-
   // Set durability
   if (qos_profile.durability() == rclcpp::DurabilityPolicy::TransientLocal) {
     rmw_qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-  } else {
-    rmw_qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
   }
-
-  // Set history policy and depth
-  rmw_qos.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
-  rmw_qos.depth = qos_profile.depth();
 
   return rmw_qos;
 }

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -43,8 +43,8 @@ std::optional<rmw_qos_profile_t> ImageTransportImageStreamer::detect_publisher_q
   }
 
   // Use the first publisher's QoS as reference.
-  auto endpoint_info = topic_endpoint_info_array.front();
-  auto qos_profile = endpoint_info.qos_profile();
+  const auto endpoint_info = topic_endpoint_info_array.front();
+  const auto qos_profile = endpoint_info.qos_profile();
 
   // Log the detected QoS settings.
   std::string reliability =

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -56,7 +56,7 @@ std::optional<rmw_qos_profile_t> ImageTransportImageStreamer::detect_publisher_q
               reliability.c_str(), durability.c_str(), qos_profile.depth());
 
   // Convert rclcpp QoS to rmw QoS profile.
-  rmw_qos_profile_t rmw_qos = rmw_qos_profile_default;
+  auto rmw_qos = rmw_qos_profile_default;
 
   // Set defaults
   rmw_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -1,38 +1,25 @@
+
 #include "web_video_server/image_streamer.h"
 #include <cv_bridge/cv_bridge.h>
 #include <iostream>
+#include <optional>
 
-namespace web_video_server
+namespace
 {
-
-ImageStreamer::ImageStreamer(const async_web_server_cpp::HttpRequest &request,
-                             async_web_server_cpp::HttpConnectionPtr connection, rclcpp::Node::SharedPtr nh) :
-    request_(request), connection_(connection), nh_(nh), inactive_(false)
-{
-  topic_ = request.get_query_param_value_or_default("topic", "");
-}
-
-ImageStreamer::~ImageStreamer()
-{
-}
-
-ImageTransportImageStreamer::ImageTransportImageStreamer(const async_web_server_cpp::HttpRequest &request,
-                             async_web_server_cpp::HttpConnectionPtr connection, rclcpp::Node::SharedPtr nh) :
-  ImageStreamer(request, connection, nh), it_(nh), initialized_(false)
-{
-  output_width_ = request.get_query_param_value_or_default<int>("width", -1);
-  output_height_ = request.get_query_param_value_or_default<int>("height", -1);
-  invert_ = request.has_query_param("invert");
-  default_transport_ = request.get_query_param_value_or_default("default_transport", "raw");
-  qos_profile_name_ = request.get_query_param_value_or_default("qos_profile", "auto");
-}
-
-ImageTransportImageStreamer::~ImageTransportImageStreamer()
-{
-}
-
-std::optional<rmw_qos_profile_t> ImageTransportImageStreamer::detect_publisher_qos(rclcpp::Node::SharedPtr nh, 
-                                                                                   const std::string &topic) 
+/**
+ * @brief Detects QoS profile settings used by publishers on a specified topic.
+ * 
+ * This function queries the ROS2 middleware to discover publishers on the 
+ * given topic and extracts their QoS profile settings. It's useful for 
+ * creating subscribers that automatically match the publisher's QoS.
+ * 
+ * @param nh The ROS2 node.
+ * @param topic The full name of the topic to query.
+ *
+ * @return The detected QoS profile if a publisher is found, std::nullopt otherwise
+ */
+std::optional<rmw_qos_profile_t> detect_publisher_qos(rclcpp::Node::SharedPtr nh, 
+                                                      const std::string &topic) 
 {
   RCLCPP_INFO(nh->get_logger(), "Attempting to auto-detect QoS for topic: %s", topic.c_str());
 
@@ -76,9 +63,22 @@ std::optional<rmw_qos_profile_t> ImageTransportImageStreamer::detect_publisher_q
   return rmw_qos;
 }
 
-std::optional<rmw_qos_profile_t> ImageTransportImageStreamer::get_qos_profile(rclcpp::Node::SharedPtr nh, 
-                                                                              const  std::string &profile_name, 
-                                                                              const std::string& topic) {
+/**
+ * @brief Get QoS profile based on user selection or auto-detect.
+ * 
+ * If the profile name is "auto" (the default one), this function queries the ROS2
+ * middleware to discover publishers on the given topic and extracts their QoS
+ * profile settings. Otherwise it returns a profile based on the given name.
+ * 
+ * @param nh The ROS2 node.
+ * @param profile_name The QoS profile name e.g. "auto" or "default".
+ * @param topic The full name of the topic to query.
+ *
+ * @return The detected QoS profile if a publisher is found, std::nullopt otherwise
+ */
+std::optional<rmw_qos_profile_t> get_qos_profile(rclcpp::Node::SharedPtr nh, 
+                                                 const  std::string &profile_name, 
+                                                 const std::string& topic) {
   std::optional<rmw_qos_profile_t> qos_profile;
   if (profile_name == "auto") {
     // Auto-detect QoS from publisher
@@ -93,7 +93,7 @@ std::optional<rmw_qos_profile_t> ImageTransportImageStreamer::get_qos_profile(rc
     // Use named profile
     RCLCPP_INFO(nh->get_logger(), "Using specified QoS profile %s for topic %s", profile_name.c_str(),
                 topic.c_str());
-    qos_profile = get_qos_profile_from_name(profile_name);
+    qos_profile = web_video_server::get_qos_profile_from_name(profile_name);
     if (!qos_profile) {
       qos_profile = rmw_qos_profile_default;
       RCLCPP_ERROR(nh->get_logger(), "Invalid QoS profile %s specified. Using default profile.",
@@ -102,6 +102,36 @@ std::optional<rmw_qos_profile_t> ImageTransportImageStreamer::get_qos_profile(rc
   }
   return qos_profile;
 
+}
+}
+
+namespace web_video_server
+{
+
+ImageStreamer::ImageStreamer(const async_web_server_cpp::HttpRequest &request,
+                             async_web_server_cpp::HttpConnectionPtr connection, rclcpp::Node::SharedPtr nh) :
+    request_(request), connection_(connection), nh_(nh), inactive_(false)
+{
+  topic_ = request.get_query_param_value_or_default("topic", "");
+}
+
+ImageStreamer::~ImageStreamer()
+{
+}
+
+ImageTransportImageStreamer::ImageTransportImageStreamer(const async_web_server_cpp::HttpRequest &request,
+                             async_web_server_cpp::HttpConnectionPtr connection, rclcpp::Node::SharedPtr nh) :
+  ImageStreamer(request, connection, nh), it_(nh), initialized_(false)
+{
+  output_width_ = request.get_query_param_value_or_default<int>("width", -1);
+  output_height_ = request.get_query_param_value_or_default<int>("height", -1);
+  invert_ = request.has_query_param("invert");
+  default_transport_ = request.get_query_param_value_or_default("default_transport", "raw");
+  qos_profile_name_ = request.get_query_param_value_or_default("qos_profile", "auto");
+}
+
+ImageTransportImageStreamer::~ImageTransportImageStreamer()
+{
 }
 
 void ImageTransportImageStreamer::start()

--- a/src/image_streamer.cpp
+++ b/src/image_streamer.cpp
@@ -24,11 +24,87 @@ ImageTransportImageStreamer::ImageTransportImageStreamer(const async_web_server_
   output_height_ = request.get_query_param_value_or_default<int>("height", -1);
   invert_ = request.has_query_param("invert");
   default_transport_ = request.get_query_param_value_or_default("default_transport", "raw");
-  qos_profile_name_ = request.get_query_param_value_or_default("qos_profile", "default");
+  qos_profile_name_ = request.get_query_param_value_or_default("qos_profile", "auto");
 }
 
 ImageTransportImageStreamer::~ImageTransportImageStreamer()
 {
+}
+
+std::optional<rmw_qos_profile_t> ImageTransportImageStreamer::detect_publisher_qos(rclcpp::Node::SharedPtr nh, 
+                                                                                   const std::string &topic) 
+{
+  RCLCPP_INFO(nh->get_logger(), "Attempting to auto-detect QoS for topic: %s", topic.c_str());
+
+  auto topic_endpoint_info_array = nh->get_publishers_info_by_topic(topic);
+  if (topic_endpoint_info_array.empty()) {
+    RCLCPP_WARN(nh->get_logger(), "No publishers found for topic: %s", topic.c_str());
+    return std::nullopt;
+  }
+
+  // Use the first publisher's QoS as reference.
+  auto endpoint_info = topic_endpoint_info_array.front();
+  auto qos_profile = endpoint_info.qos_profile();
+
+  // Log the detected QoS settings.
+  std::string reliability =
+      (qos_profile.reliability() == rclcpp::ReliabilityPolicy::Reliable) ? "RELIABLE" : "BEST_EFFORT";
+  std::string durability =
+      (qos_profile.durability() == rclcpp::DurabilityPolicy::TransientLocal) ? "TRANSIENT_LOCAL" : "VOLATILE";
+
+  RCLCPP_INFO(nh->get_logger(), "Detected QoS - Reliability: %s, Durability: %s, History depth: %zu",
+              reliability.c_str(), durability.c_str(), qos_profile.depth());
+
+  // Convert rclcpp QoS to rmw QoS profile.
+  rmw_qos_profile_t rmw_qos = rmw_qos_profile_default;
+
+  // Set reliability
+  if (qos_profile.reliability() == rclcpp::ReliabilityPolicy::Reliable) {
+    rmw_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  } else {
+    rmw_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  }
+
+  // Set durability
+  if (qos_profile.durability() == rclcpp::DurabilityPolicy::TransientLocal) {
+    rmw_qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+  } else {
+    rmw_qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+  }
+
+  // Set history policy and depth
+  rmw_qos.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+  rmw_qos.depth = qos_profile.depth();
+
+  return rmw_qos;
+}
+
+std::optional<rmw_qos_profile_t> ImageTransportImageStreamer::get_qos_profile(rclcpp::Node::SharedPtr nh, 
+                                                                              const  std::string &profile_name, 
+                                                                              const std::string& topic) {
+  std::optional<rmw_qos_profile_t> qos_profile;
+  if (profile_name == "auto") {
+    // Auto-detect QoS from publisher
+    qos_profile = detect_publisher_qos(nh, topic);
+    if (!qos_profile) {
+      RCLCPP_WARN(nh->get_logger(), "Could not auto-detect QoS for topic %s. Using default profile.", topic.c_str());
+      qos_profile = rmw_qos_profile_default;
+    } else {
+      RCLCPP_INFO(nh->get_logger(), "Using auto-detected QoS profile for topic %s", topic.c_str());
+    }
+  } else {
+    // Use named profile
+    RCLCPP_INFO(nh->get_logger(), "Using specified QoS profile %s for topic %s", profile_name.c_str(),
+                topic.c_str());
+    qos_profile = get_qos_profile_from_name(profile_name);
+    if (!qos_profile) {
+      qos_profile = rmw_qos_profile_default;
+      RCLCPP_ERROR(nh->get_logger(), "Invalid QoS profile %s specified. Using default profile.",
+                   profile_name.c_str());
+    }
+  }
+  return qos_profile;
+
 }
 
 void ImageTransportImageStreamer::start()
@@ -48,16 +124,8 @@ void ImageTransportImageStreamer::start()
     }
   }
 
-  // Get QoS profile from query parameter
-  RCLCPP_INFO(nh_->get_logger(), "Streaming topic %s with QoS profile %s", topic_.c_str(), qos_profile_name_.c_str());
-  auto qos_profile = get_qos_profile_from_name(qos_profile_name_);
-  if (!qos_profile) {
-    qos_profile = rmw_qos_profile_default;
-    RCLCPP_ERROR(
-      nh_->get_logger(),
-      "Invalid QoS profile %s specified. Using default profile.",
-      qos_profile_name_.c_str());
-  }
+  // Get QoS profile based on user selection or auto-detect.
+  std::optional<rmw_qos_profile_t> qos_profile = get_qos_profile(nh_, qos_profile_name_, topic_);
 
   // Create subscriber
   using std::placeholders::_1;


### PR DESCRIPTION
In this PR we introduce a feature to inspect the publisher QoS before connecting a subscriber.

This is particularly useful when we have a Publisher that uses the QoS durability Transient Local. With this configuration, a publisher retains the last frame in a cache. When a subscriber connects to this kind of publisher, it is notified of the last image cached.

This is usually not desirable for a publisher that sends images at a high rate, where QoS Volatile is preferable. But it is useful in topics with a very low frame rate.